### PR TITLE
Fix showing a blank screen that cannot be exited if there is no confi…

### DIFF
--- a/Assets/Scripts/ConfigFile.cs
+++ b/Assets/Scripts/ConfigFile.cs
@@ -16,19 +16,6 @@ public static class ConfigFile
         // TODO: Make magic numbers for configs into constants defined in this class
         TomlTable tomlConfigTable = Toml.Create();
 
-        Dictionary<string, object> keyConfigDict = new Dictionary<string, object>();
-        keyConfigDict.Add("Left", 37);
-        keyConfigDict.Add("Right", 39);
-        keyConfigDict.Add("Up", 38);
-        keyConfigDict.Add("Down", 40);
-        keyConfigDict.Add("Exit", 115);
-        keyConfigDict.Add("Back", 27);
-        keyConfigDict.Add("Back2", 8);
-        keyConfigDict.Add("Auto", 113);
-        keyConfigDict.Add("Select", 13);
-        keyConfigDict.Add("GameOptions", 112);
-        tomlConfigTable.Add("KeyConfig", keyConfigDict);
-
         Dictionary<string, object> touchConfigDict = new Dictionary<string, object>();
         touchConfigDict.Add("WidthAxis", 1);
         touchConfigDict.Add("CalMinX", 0);
@@ -61,8 +48,6 @@ public static class ConfigFile
 
         configTable = Toml.ReadFile(Defines.ConfigFile).ToDictionary();
 
-        //if (configTable.ContainsKey(Defines.KeyConfig))
-        //    InputMonitor.SetKeys((Dictionary<string, object>)configTable[Defines.KeyConfig]);
         if (configTable.ContainsKey(Defines.TouchConfig))
             TouchSettings.SetConfig((Dictionary<string, object>)configTable[Defines.TouchConfig]);
         //if (configTable.ContainsKey(Defines.GameConfig))
@@ -76,7 +61,6 @@ public static class ConfigFile
     {
         configTable = new Dictionary<string, object>()
             {
-                //{Defines.KeyConfig, InputMonitor.GetConfig() },
                 {Defines.TouchConfig, TouchSettings.GetConfig() },
                 //{Defines.GameConfig, GameSettingsScreen.GetConfig() }
             };
@@ -89,7 +73,6 @@ public static class ConfigFile
 
         var data = new Dictionary<string, object>()
             {
-                //{Defines.KeyConfig, InputMonitor.GetConfig() },
                 {Defines.TouchConfig, TouchSettings.GetConfig() },
                 //{Defines.GameConfig, GameSettingsScreen.GetConfig() }
             };

--- a/Assets/Scripts/ConfigFile.cs
+++ b/Assets/Scripts/ConfigFile.cs
@@ -11,28 +11,62 @@ public static class ConfigFile
 
     private static Dictionary<string, object> configTable;
 
+    private static void CreateConfigFile()
+    {
+        // TODO: Make magic numbers for configs into constants defined in this class
+        TomlTable tomlConfigTable = Toml.Create();
+
+        Dictionary<string, object> keyConfigDict = new Dictionary<string, object>();
+        keyConfigDict.Add("Left", 37);
+        keyConfigDict.Add("Right", 39);
+        keyConfigDict.Add("Up", 38);
+        keyConfigDict.Add("Down", 40);
+        keyConfigDict.Add("Exit", 115);
+        keyConfigDict.Add("Back", 27);
+        keyConfigDict.Add("Back2", 8);
+        keyConfigDict.Add("Auto", 113);
+        keyConfigDict.Add("Select", 13);
+        keyConfigDict.Add("GameOptions", 112);
+        tomlConfigTable.Add("KeyConfig", keyConfigDict);
+
+        Dictionary<string, object> touchConfigDict = new Dictionary<string, object>();
+        touchConfigDict.Add("WidthAxis", 1);
+        touchConfigDict.Add("CalMinX", 0);
+        touchConfigDict.Add("CalMaxX", 1280);
+        touchConfigDict.Add("CalMinY", 0);
+        touchConfigDict.Add("CalMaxY", 720);
+        touchConfigDict.Add("AbsX", 1024);
+        touchConfigDict.Add("AbsY", 1024);
+        tomlConfigTable.Add("TouchConfig", touchConfigDict);
+
+        Dictionary<string, object> gameConfigDict = new Dictionary<string, object>();
+        gameConfigDict.Add("Language", 0);
+        gameConfigDict.Add("Resolution", 0);
+        gameConfigDict.Add("TouchScreenOrientation", 1);
+        gameConfigDict.Add("EnableFreePlay", true);
+        gameConfigDict.Add("AutoMode", 0);
+        tomlConfigTable.Add("GameConfig", gameConfigDict);
+
+        Toml.WriteFile(tomlConfigTable, Defines.ConfigFile);
+    }
+
     public static bool Load(string filepath = "")
     {
         if (!String.IsNullOrEmpty(filepath))
             FilePath = filepath;
 
-        // Load config file
-        if (File.Exists(Defines.ConfigFile))
-        {
-            configTable = Toml.ReadFile(Defines.ConfigFile).ToDictionary();
+        // build defaults
+        if (!File.Exists(Defines.ConfigFile))
+            CreateConfigFile();
 
-            //if (configTable.ContainsKey(Defines.KeyConfig))
-            //    InputMonitor.SetKeys((Dictionary<string, object>)configTable[Defines.KeyConfig]);
-            if (configTable.ContainsKey(Defines.TouchConfig))
-                TouchSettings.SetConfig((Dictionary<string, object>)configTable[Defines.TouchConfig]);
-            //if (configTable.ContainsKey(Defines.GameConfig))
-            //    GameSettingsScreen.SetConfig((Dictionary<string, object>)configTable[Defines.GameConfig]);
-        }
-        else
-        {
-            // Build defaults
+        configTable = Toml.ReadFile(Defines.ConfigFile).ToDictionary();
 
-        }
+        //if (configTable.ContainsKey(Defines.KeyConfig))
+        //    InputMonitor.SetKeys((Dictionary<string, object>)configTable[Defines.KeyConfig]);
+        if (configTable.ContainsKey(Defines.TouchConfig))
+            TouchSettings.SetConfig((Dictionary<string, object>)configTable[Defines.TouchConfig]);
+        //if (configTable.ContainsKey(Defines.GameConfig))
+        //    GameSettingsScreen.SetConfig((Dictionary<string, object>)configTable[Defines.GameConfig]);
 
         IsLoaded = true;
         return true;

--- a/Assets/Scripts/Defines.cs
+++ b/Assets/Scripts/Defines.cs
@@ -7,7 +7,6 @@
         public static readonly string ZipExtension = ".ssz";
 
         public static readonly string ConfigFile = "config.toml";
-        public static readonly string KeyConfig = "KeyConfig";
         public static readonly string TouchConfig = "TouchConfig";
         public static readonly string GameConfig = "GameConfig";
 


### PR DESCRIPTION
…g file present. Fix this by creating a config file on the fly if it's not available.

I tested this by seeing that I can now move around in the options menu if a config file is generated on the fly. Of course, we will not generate a config file if it's already been generated.