### PR TITLE
Attach librefranklin-mplus SDF material to text objects so text will …

### DIFF
--- a/Assets/Scenes/GameSettingsScreen.unity
+++ b/Assets/Scenes/GameSettingsScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -313,7 +313,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: Option Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -381,18 +381,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: -855.8947, w: 13.179931}
   m_textInfo:
     textComponent: {fileID: 629079942}
-    characterCount: 11
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -683,7 +683,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: OPTION TITLE
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -751,18 +751,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: -694.18225, w: 5.2552605}
   m_textInfo:
     textComponent: {fileID: 1144200872}
-    characterCount: 12
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -911,7 +911,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: Press CONFIRM to blank blank changes.
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -979,18 +979,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: -694.18225, w: 5.2552605}
   m_textInfo:
     textComponent: {fileID: 1507298977}
-    characterCount: 37
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 5
-    wordCount: 6
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}

--- a/Assets/Scenes/GameplayScreen.unity
+++ b/Assets/Scenes/GameplayScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 170076734}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -169,7 +169,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: TITLE TEXT
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -237,18 +237,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 18579928}
-    characterCount: 10
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -325,7 +325,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 1
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -393,18 +393,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 26017404}
-    characterCount: 1
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -956,7 +956,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -1024,18 +1024,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 200814666}
-    characterCount: 3
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1585,7 +1585,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -1653,18 +1653,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 466296526}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1743,7 +1743,7 @@ MonoBehaviour:
 
 '
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -1811,18 +1811,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 471252228}
-    characterCount: 18
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 3
-    wordCount: 3
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 2
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2146,7 +2146,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: NORMAL
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -2214,18 +2214,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 635396146}
-    characterCount: 6
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2460,7 +2460,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: .0
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -2528,18 +2528,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 767558617}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2695,7 +2695,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: ARTIST TEXT GOES HERE
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -2763,18 +2763,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 932387257}
-    characterCount: 21
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 3
-    wordCount: 4
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3002,7 +3002,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: .00%
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -3070,18 +3070,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1029358891}
-    characterCount: 4
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3270,7 +3270,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: SCROLL
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -3338,18 +3338,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1262539375}
-    characterCount: 6
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3661,7 +3661,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: ACCURACY
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -3729,18 +3729,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1724607237}
-    characterCount: 8
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}

--- a/Assets/Scenes/ResultScreen.unity
+++ b/Assets/Scenes/ResultScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -169,8 +169,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -325,8 +325,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: COOL
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -404,7 +404,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -481,8 +481,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00.000%
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: e0c7ac416e11f024b9f98180c52f996b, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -559,7 +560,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -852,8 +853,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: MISS
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -931,7 +932,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1236,8 +1237,9 @@ MonoBehaviour:
       m_Calls: []
   m_text: SONG TITLE
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: 5de510c68d6e7fc4f8b575e9c12cfc51, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1314,7 +1316,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1395,8 +1397,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: RESULT
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1474,7 +1476,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1849,8 +1851,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1928,7 +1930,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2149,8 +2151,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: GOOD
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2228,7 +2230,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2305,8 +2307,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: DIFFICULTY Lv.00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2384,7 +2386,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2530,8 +2532,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: ACCURACY
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2609,7 +2611,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2977,8 +2979,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: STYLISH
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3056,7 +3058,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3352,8 +3354,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3431,7 +3433,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3580,8 +3582,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3659,7 +3661,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3736,8 +3738,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: ARTIST NAME
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3815,7 +3817,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}

--- a/Assets/Scenes/SongSelection.unity
+++ b/Assets/Scenes/SongSelection.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -169,7 +169,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -236,18 +236,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 130421336}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -324,7 +324,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: Title Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -392,18 +392,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 131631065}
-    characterCount: 10
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -480,7 +480,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -547,18 +547,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 160557720}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -707,7 +707,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -774,18 +774,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 333719887}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -862,8 +862,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'Choreo: ???'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -941,7 +941,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1603,7 +1603,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1670,18 +1670,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 872000072}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1760,7 +1760,7 @@ MonoBehaviour:
 
     Second Line'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -1828,18 +1828,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 880017239}
-    characterCount: 22
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 3
-    wordCount: 4
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 2
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -1985,8 +1985,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Title Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2064,7 +2064,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2216,7 +2216,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2283,18 +2283,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1077273100}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2515,8 +2515,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Artist Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2594,7 +2594,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2743,7 +2743,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -2810,18 +2810,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1125255911}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -2970,8 +2970,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: ??? BPM
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3049,7 +3049,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3584,7 +3584,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: Artist Text
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
     type: 2}
   m_fontSharedMaterials: []
@@ -3652,18 +3652,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1617722161}
-    characterCount: 11
+    characterCount: 0
     spriteCount: 0
-    spaceCount: 1
-    wordCount: 2
+    spaceCount: 0
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3812,7 +3812,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -3879,18 +3879,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1698652680}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -3967,7 +3967,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -4034,18 +4034,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1755466676}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -4122,7 +4122,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -4189,18 +4189,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1763942897}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -4277,7 +4277,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -4344,18 +4344,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1793770884}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -4434,8 +4434,8 @@ MonoBehaviour:
 
     ENABLED'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
-  m_sharedMaterial: {fileID: 21214959179828010, guid: 722c3f0e8a8609845bdd184679820974,
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
+  m_sharedMaterial: {fileID: 21214959179828010, guid: 7655c4480789a5a4dbcc40015cbf15d5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -4513,7 +4513,7 @@ MonoBehaviour:
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -4746,7 +4746,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -4813,18 +4813,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 1929277931}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}
@@ -4973,7 +4973,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 00
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 722c3f0e8a8609845bdd184679820974, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 7655c4480789a5a4dbcc40015cbf15d5, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: 6cb4ff256b1e0dd43baeec50edaeecf9, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -5040,18 +5040,18 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 2102983570}
-    characterCount: 2
+    characterCount: 0
     spriteCount: 0
     spaceCount: 0
-    wordCount: 1
+    wordCount: 0
     linkCount: 0
-    lineCount: 1
-    pageCount: 1
+    lineCount: 0
+    pageCount: 0
     materialCount: 1
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_spriteAnimator: {fileID: 0}
-  m_hasFontAssetChanged: 0
+  m_hasFontAssetChanged: 1
   m_subTextObjects:
   - {fileID: 0}
   - {fileID: 0}

--- a/Assets/Scripts/ConfigFile.cs
+++ b/Assets/Scripts/ConfigFile.cs
@@ -50,8 +50,6 @@ public static class ConfigFile
 
         if (configTable.ContainsKey(Defines.TouchConfig))
             TouchSettings.SetConfig((Dictionary<string, object>)configTable[Defines.TouchConfig]);
-        //if (configTable.ContainsKey(Defines.GameConfig))
-        //    GameSettingsScreen.SetConfig((Dictionary<string, object>)configTable[Defines.GameConfig]);
 
         IsLoaded = true;
         return true;
@@ -62,7 +60,7 @@ public static class ConfigFile
         configTable = new Dictionary<string, object>()
             {
                 {Defines.TouchConfig, TouchSettings.GetConfig() },
-                //{Defines.GameConfig, GameSettingsScreen.GetConfig() }
+                {Defines.GameConfig, GameSettingsScreen.GetConfig() }
             };
     }
 
@@ -71,15 +69,8 @@ public static class ConfigFile
         if (!String.IsNullOrEmpty(filepath))
             FilePath = filepath;
 
-        var data = new Dictionary<string, object>()
-            {
-                {Defines.TouchConfig, TouchSettings.GetConfig() },
-                //{Defines.GameConfig, GameSettingsScreen.GetConfig() }
-            };
-        Toml.WriteFile(data, Defines.ConfigFile);
-
-        // Should this go here? I don't see why we would save if we didn't want to apply it immediately
-        //UpdateGlobals();
+        File.Delete(Defines.ConfigFile); // delete file before writing another TOML file
+        Toml.WriteFile(configTable, Defines.ConfigFile);
     }
 
     //public Dictionary<string, object> this[string key]

--- a/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreen.cs
+++ b/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreen.cs
@@ -49,6 +49,12 @@ namespace StyleStar
                 };
                 isInitialized = true;
             }
+            else
+            {
+                // We need to do this because the pool gets deleted every time we exit from this menu.
+                foreach (var option in options)
+                    option.InitializeOptionObj();
+            }
         }
 
         public static void Draw()

--- a/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreenDisplay.cs
+++ b/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreenDisplay.cs
@@ -46,11 +46,8 @@ public class GameSettingsScreenDisplay : MonoBehaviour
         Bg2.SetColor(ThemeColors.Blue);
         Bg3.SetColor(ThemeColors.Yellow);
 
-        if(Pools.GameSettingOptions == null)
-        {
-            Pools.GameSettingOptions = ScriptableObject.CreateInstance<ObjectPooler>();
-            Pools.GameSettingOptions.SetPool(OptionBase, 10, true, this.gameObject);
-        }
+        Pools.GameSettingOptions = ScriptableObject.CreateInstance<ObjectPooler>();
+        Pools.GameSettingOptions.SetPool(OptionBase, 10, true, this.gameObject);
 
         GameSettingsScreen.Initialize(Selection, ConfirmReject);
         GameSettingsScreen.SetConfig(ConfigFile.GetTable(Defines.GameConfig));

--- a/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreenInputs.cs
+++ b/Assets/Scripts/Screens/GameSettingsScreen/GameSettingsScreenInputs.cs
@@ -29,8 +29,15 @@ public class GameSettingsScreenInputs : MonoBehaviour
             GameSettingsScreen.ScrollRight();
         else if (Input.GetButtonDown("Select"))
         {
-            if (GameSettingsScreen.Select() != DialogResult.NoAction)
+            DialogResult gameSettingResult = GameSettingsScreen.Select();
+            if (gameSettingResult != DialogResult.NoAction)
             {
+                // save the TOML file here
+                if (gameSettingResult == DialogResult.Confirm)
+                {
+                    ConfigFile.Update();
+                    ConfigFile.Save();
+                }
                 GameState.TransitionState = TransitionState.EnteringLoadingScreen;
                 GameState.Destination = Mode.SongSelect;
             }

--- a/Assets/Scripts/Screens/GameSettingsScreen/SettingOption.cs
+++ b/Assets/Scripts/Screens/GameSettingsScreen/SettingOption.cs
@@ -23,13 +23,16 @@ namespace StyleStar
 
         public SettingOption(string title, string[] options)
         {
-            optionObj = Pools.GameSettingOptions.GetPooledObject();
-
             Title = title;
+            Options.AddRange(options);
+            InitializeOptionObj();
+        }
+
+        public void InitializeOptionObj()
+        {
+            optionObj = Pools.GameSettingOptions.GetPooledObject();
             var titleObj = optionObj.GetComponent<TextMeshProUGUI>();
             titleObj.text = Title;
-            Options.AddRange(options);
-
             optionObj.SetActive(true);
         }
 


### PR DESCRIPTION
…show in the unity builds.

With these changes, I'll be able to write up the README for building/setting up the StyleStar-Unity project.

Of course, this works in my local build, but we might want to test to see if these changes are reflected in earlier/later versions of Unity so these don't get corrupted in some way.